### PR TITLE
Include version.txt in the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include version.txt


### PR DESCRIPTION
Otherwise the package will get installed as version 0.0.0, because setup.py wouldn't be able to find the correct version.