### PR TITLE
Add tox pre-publish config

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -168,16 +168,6 @@ enable=F,
        bad-string-format-type,
        bad-str-strip-call,
        invalid-envvar-value,
-       print-statement,
-       parameter-unpacking,
-       unpacking-in-except,
-       old-raise-syntax,
-       backtick,
-       long-suffix,
-       old-ne-operator,
-       old-octal-literal,
-       import-star-module-level,
-       non-ascii-bytes-literal,
        yield-inside-async-function,
        not-async-context-manager,
        fatal,
@@ -635,5 +625,5 @@ preferred-modules=
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-;envlist = py{37,38,39,310,311,312}
 minversion = 4.0
 
 [testenv]
@@ -11,8 +10,13 @@ deps =
     pytest-cov
 commands =
     pytest --cov=. --import-mode=append {tty:--color=yes} {posargs}
-;    - coverage combine
-;    - coverage xml
 pass_env =
     resource_key
     license_key
+
+[testenv:pre-publish]
+package = skip
+deps =
+    pytest>=6
+    pytest-cov
+    -r ../package/pre-publish-requirements.txt


### PR DESCRIPTION
This config will be used during `publish` pipeline to enable use of prebuilt package

Additionally, deprecated `pylint` rules were removed from its config file